### PR TITLE
Fix code scanning alert no. 4: Disallow unused variables

### DIFF
--- a/utils/msgUtils.ts
+++ b/utils/msgUtils.ts
@@ -5,7 +5,7 @@ const parser = new XMLBuilder({});
 
 const getLogicCheck = (input: string, nonce: string): string => {
   return Array.from(nonce)
-    .map((char, i) => input[char.charCodeAt(0) & 0xf])
+    .map(char => input[char.charCodeAt(0) & 0xf])
     .join("");
 };
 


### PR DESCRIPTION
Fixes [https://github.com/mazurikian/samfirm.js/security/code-scanning/4](https://github.com/mazurikian/samfirm.js/security/code-scanning/4)

To fix the problem, we need to remove the unused variable `i` from the `map` function. This will eliminate the ESLint error and make the code cleaner and more maintainable. The change should be made in the `getLogicCheck` function, specifically on line 8 where the `map` function is defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
